### PR TITLE
Compile error under XCode/MacOS

### DIFF
--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -43,7 +43,7 @@ void CDBEnv::EnvShutdown()
     if (ret != 0)
         LogPrintf("CDBEnv::EnvShutdown: Error %d shutting down database environment: %s\n", ret, DbEnv::strerror(ret));
     if (!fMockDb)
-        DbEnv(0).remove(strPath.c_str(), 0);
+        DbEnv((u_int32_t)0).remove(strPath.c_str(), 0);
 }
 
 void CDBEnv::Reset()


### PR DESCRIPTION
DbEnv(0).remove(strPath.c_str(), 0);

其中DbEnv(0)的0，XCODE分不清是指针还是数字，因而编译出现错误。
用u_int32_t定义成数字就好了。